### PR TITLE
add favicon redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ app.get('/__gtg', (req, res) => {
   res.send('ok');
 });
 
-app.get('/favicon.ico', (req, res)=>{
+app.get('/favicon.ico', (req, res)=>{ //explicit override to redirect if favicon is requested
   res.redirect(301, 'https://ig.ft.com/favicon.ico');
 });
 


### PR DESCRIPTION
necessary for SVG when not requested via ig.ft domain. As they  don’t define favicon explicitly.
