### PR TITLE
Chart sizes, also add option to remove text

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ async function makePollTimeSeries(chartOpts){
 
   const options = {
     fontless: (typeof chartOpts.fontless === 'boolean' ? chartOpts.fontless : (chartOpts.fontless ? chartOpts.fontless === 'true' : true)),
-    noheadline: typeof chartOpts.noheadline === 'boolean' ? chartOpts.noheadline : false,
+    notext: typeof chartOpts.notext === 'boolean' ? chartOpts.notext : false,
     background: chartOpts.background || 'none',
     startDate: chartOpts.startDate || 'June 1, 2016',
     endDate: chartOpts.endDate || formattedNowDate,
@@ -223,7 +223,7 @@ async function statePage(req, res) {
     async function getPollSVG(size = '600x300') {
       return makePollTimeSeries({
         fontless: true,
-        noheadline: true,
+        notext: true,
         startDate: 'June 1, 2016',
         size: size,
         type: 'area',
@@ -271,11 +271,11 @@ async function statePage(req, res) {
       lastUpdated: await lastUpdated(),
       introText: introText,
       pollSVG: {
-        default: await getPollSVG('320x250'),
-        S: await getPollSVG('550x320'),
-        M: await getPollSVG('625x350'),
-        L: await getPollSVG('660x390'),
-        XL: await getPollSVG('680x350'),
+        default: await getPollSVG('355x200'),
+        S: await getPollSVG('630x270'),
+        M: await getPollSVG('603x270'),
+        L: await getPollSVG('650x288'),
+        XL: await getPollSVG('680x310'),
       },
       pollList: formattedIndividualPolls,
       canonicalURL: canonicalURL,

--- a/layouts/drawChart.js
+++ b/layouts/drawChart.js
@@ -19,7 +19,7 @@ async function drawChart(options, data) {
 
   const window = await getJSDomWindow(htmlStub);
   const el = window.document.querySelector('#dataviz-container');
-  const margins = { top: options.noheadline ? 30 : 70, bottom: 70, left: 35, right: 30 };
+  const margins = { top: options.notext ? 15 : 70, bottom: options.notext ? 40 : 70, left: 35, right: 30 };
   const userInputParse = d3.timeParse('%B %e, %Y');
   const colors = { Clinton: '#238fce', Trump: '#e5262d' };
   const areaColors = { Clinton: '#a2c1e1', Trump: '#f4a098' };
@@ -361,7 +361,7 @@ async function drawChart(options, data) {
     });
 
 
-  if (!options.noheadline) {
+  if (!options.notext) {
     annotationGroup.append('text')
       .text(function() {
         const stateName = _.findWhere(stateIds, { 'state': options.state.toUpperCase() }).stateName;
@@ -379,34 +379,33 @@ async function drawChart(options, data) {
       .attr('class', 'headline')
       .attr('x', -margins.left + 7)
       .attr('y', -margins.top + 24);
-  }
 
-
-  const subhead = annotationGroup.append('text')
-    .text(function() {
-      let statePrefix;
-      if (options.width < 300) {
-        statePrefix = 'Polling ';
-      } else {
-        if (options.state === 'us') {
-          statePrefix = 'National polling ';
-        } else {
+    annotationGroup.append('text')
+      .text(function() {
+        let statePrefix;
+        if (options.width < 300) {
           statePrefix = 'Polling ';
+        } else {
+          if (options.state === 'us') {
+            statePrefix = 'National polling ';
+          } else {
+            statePrefix = 'Polling ';
+          }
         }
-      }
 
-      return statePrefix + 'average as of ' + d3.timeFormat('%B %e, %Y')(new Date(formattedData[formattedData.length - 1].date)) + ' (%)'
-    })
-    .attr('class', 'subhead')
-    .attr('x', -margins.left + 7)
-    .attr('y', -margins.top + (options.noheadline ? 10 : 46));
+        return statePrefix + 'average as of ' + d3.timeFormat('%B %e, %Y')(new Date(formattedData[formattedData.length - 1].date)) + ' (%)'
+      })
+      .attr('class', 'subhead')
+      .attr('x', -margins.left + 7)
+      .attr('y', -margins.top + 46);
 
-  const sourceline = annotationGroup.append('text')
-    .text('Source: Real Clear Politics')
-    .attr('class', 'sourceline')
-    .attr('x', -margins.left + 7)
-    .attr('y', options.height - margins.top - 10)
-    .style('text-anchor', 'start');
+    sourceline = annotationGroup.append('text')
+      .text('Source: Real Clear Politics')
+      .attr('class', 'sourceline')
+      .attr('x', -margins.left + 7)
+      .attr('y', options.height - margins.top - 10)
+      .style('text-anchor', 'start');
+  }
 
   const config = {
     width: options.width,

--- a/views/polls.html
+++ b/views/polls.html
@@ -113,28 +113,30 @@ body {
 @media (max-width: 30.615em) {
   .o-typography-heading1 {
     font-size: 26px;
-    line-height: 1.2;
+    line-height: 1.1;
   }
   .o-typography-body-wrapper p {
     font-size: 16px;
   }
 
   .o-typography-body-wrapper h2 {
-    font-size: 22px
+    font-size: 20px;
+    line-height: 1.1;
   }
 }
 
 @media (max-width: 46.24em) and (min-width: 30.625em) {
   .o-typography-heading1 {
     font-size: 26px;
-    line-height: 1.2;
+    line-height: 1.1;
   }
   .o-typography-body-wrapper p {
     font-size: 16px;
   }
 
   .o-typography-body-wrapper h2 {
-    font-size: 22px
+    font-size: 20px;
+    line-height: 1.1;
   }
 }
 
@@ -154,8 +156,29 @@ body {
   padding-top: 20px;
 }
 
-.article__figure h2 {
+.article-figure {
+  font-family: MetricWeb, sans-serif;
+}
+
+.article-figure .article-figure__heading {
   margin-bottom: 0;
+  font-family: inherit;
+}
+
+.article-figure .article-figure__subheading {
+  color: #6b6e68;
+  font-size: 16px;
+  font-family: inherit;
+  margin-top: 0.3em;
+  margin-bottom: 0.5em;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+@media (max-width: 46.24em) {
+  .article-figure .article-figure__subheading {
+    font-size: 14px;
+  }
 }
 
 table {
@@ -219,7 +242,6 @@ td.date{
 }
 
 .pollchart {
-  padding-top: 10px;
   display: none;
   margin: 0 auto;
 }
@@ -258,8 +280,6 @@ a {
   text-decoration: none;
 }
 
-/* chart sizing */
-
 @media (max-width: 30.615em) {
   .pollchart.pollchart--default {
     display: block;
@@ -275,7 +295,7 @@ a {
     display: block;
   }
   .pollchart.pollchart--S svg {
-    max-width: 610px;
+    max-width: 705px;
   }
 }
 
@@ -284,6 +304,7 @@ a {
     display: block;
   }
   .pollchart.pollchart--M svg {
+    max-width: 657px;
   }
 }
 
@@ -292,13 +313,14 @@ a {
     display: block;
   }
   .pollchart.pollchart--L svg {
-    max-width: 680px;
+    max-width: 708px;
   }
 }
 
 @media (min-width: 76.25em) {
   .pollchart.pollchart--XL {
     display: block;
+    max-width: 741px;
   }
 }
 
@@ -468,15 +490,15 @@ a {
                 <p class="off-link"><a href="http://www.ft.com/us-election-2016">All US Election 2016 coverage</a></p>
                 {% endif %}
 
-                <div class="article__figure">
-                  <h2>
+                <div class="article-figure">
+                  <h2 class="article-figure__heading">
                   {% if state == "us" %}
-                    Which White House candidate is leading in the polls?
+                    Which White House candidate is leading in the polls?
                   {% else %}
-                    Which candidate is leading in STATENAME?
+                    Which candidate is leading in STATENAME?
                   {% endif %}
                   </h2>
-
+                  <p class="article-figure__subheading">Polling average</p>
                   {% for gridsize, svg in pollSVG %}
                   {% if svg %}
                   <div class="pollchart pollchart--{{gridsize}}">
@@ -484,6 +506,8 @@ a {
                   </div>
                   {% endif %}
                   {% endfor %}
+
+                  <p class="source"><small>Source: Real Clear Politics</small></p>
                 </div>
 
                 {% if state != 'us' and stateStreamURL %}


### PR DESCRIPTION
At smaller screen sizes (iPad portrait and smaller) chart dimensions
are optimized for common fixed sizes (e.g. iPhone 6, Nexus etc) rather
than arbitrary browser widths. Each size is fluid up to a point, so a
chart won’t scale to more than about 1.09 times it’s actual size,
although is can scale down  a bit more. Similarly heights are roughly
tweaked to the known device sizes - while trying to maintain a decent
aspect ratio for this kind of data - so in landscape orientation the
chart never spans more than the screen. The height values may still
need to be tweaked a little bit.

The chart drawing option removes the heading, subhead and source from
the SVG (so it can be added to the HTML). Axis ticks and plot
annotations are still rendered as part of the SVG.
