### PR TITLE
show a date in the chart subhead

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -1,13 +1,38 @@
 import nunjucks from 'nunjucks';
+import { utcFormat } from 'd3-time-format';
 
-const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
-                  'September', 'October', 'November', 'December'];
+const formatterCache = new Map();
+const defaultFTDateFormat = '%A, %-e %B %Y';
+
+export function isotime(date) {
+  if (!date) {
+    return '';
+  } else if (!(date instanceof Date)) {
+    return date;
+  }
+
+  return date.toISOString();
+}
+
+// strftime format docs: https://github.com/d3/d3-time-format
+export function strftime(date, format = defaultFTDateFormat) {
+  if (!date) {
+    return '';
+  } else if (!(date instanceof Date)) {
+    return date;
+  }
+
+  if (formatterCache.has(format)) {
+    return formatterCache.get(format)(date);
+  }
+
+  const fm = utcFormat(format);
+  formatterCache.set(format, fm);
+  return fm(date);
+}
 
 export function ftdate(d) {
-  const day = days[d.getUTCDay()];
-  const month = months[d.getUTCMonth()];
-  return !d ? '' : `${day}, ${d.getUTCDate()} ${month}, ${d.getUTCFullYear()}`;
+  return strftime(d);
 }
 
 export function commas(n) {

--- a/index.js
+++ b/index.js
@@ -144,8 +144,6 @@ async function makePollTimeSeries(chartOpts){
   return value;
 }
 
-
-
 app.get('/polls/:state.json', async (req, res) => {
   const state = req.params.state;
 
@@ -225,6 +223,7 @@ async function statePage(req, res) {
 
     // last update time
     let lastUpdatedTime = new Date(await lastUpdated());
+    const lastPollDate = lastUpdatedTime;
     const streamTextLastUpdated =  new Date(_.findWhere(data.options, { name: 'updated' }).value);
     if (streamTextLastUpdated > lastUpdatedTime) {
       lastUpdatedTime = streamTextLastUpdated;
@@ -279,10 +278,11 @@ async function statePage(req, res) {
     const polltrackerLayout = {
       // quick hack for page ID while we only have a UUID for the National page
       id: state === 'us' ? 'e01abff0-5292-11e6-9664-e0bdc13c3bef' : null,
-      state: state,
-      stateName: stateName,
+      state,
+      stateName,
       lastUpdated: lastUpdatedTime,
-      introText: introText,
+      lastPollDate,
+      introText,
       pollSVG: {
         default: await getPollSVG('355x200'),
         S: await getPollSVG('630x270'),
@@ -291,8 +291,8 @@ async function statePage(req, res) {
         XL: await getPollSVG('680x310'),
       },
       pollList: formattedIndividualPolls,
-      canonicalURL: canonicalURL,
-      stateStreamURL: stateStreamURL,
+      canonicalURL,
+      stateStreamURL,
       flags: flags(),
       share: {
         title: `US presidential election polls: It's Clinton ${latestPollAverages.Clinton}%, Trump ${latestPollAverages.Trump}%`,

--- a/views/polls.html
+++ b/views/polls.html
@@ -469,7 +469,7 @@ a {
 
               <div><a href="http://www.ft.com/us-election-2016" class="o-typography-link-topic o-typography-link-topic--medium">US Election 2016</a></div>
               <h1 class="o-typography-heading1" itemprop="headline">{% if state != 'us' %}{{ stateName }} US Election polls{% else %}US election poll tracker{% endif %}</h1>
-              <p class="o-typography-timestamp"><span class="lastupdated">Updated: </span><time itemprop="dateModified" content="{{ lastUpdated.toISOString() }}" class="o-date" data-o-component="o-date" datetime="{{ lastUpdated.toISOString() }}" data-o-date-js>{{ lastUpdated | ftdate }}</time></p>
+              <p class="o-typography-timestamp"><span class="lastupdated">Updated: </span><time itemprop="dateModified" content="{{ lastUpdated | isotime }}" class="o-date" data-o-component="o-date" datetime="{{ lastUpdated | isotime }}" data-o-date-js>{{ lastUpdated | ftdate }}</time></p>
             </header>
           </div>
         </div>
@@ -496,7 +496,7 @@ a {
                     Which candidate is leading in {{ stateName }}?
                   {% endif %}
                   </h2>
-                  <p class="article-figure__subheading">Polling average %</p>
+                  <p class="article-figure__subheading">Polling average as of {{ lastPollDate | strftime("%B %e, %Y") }} (%)</p>
                   {% for gridsize, svg in pollSVG %}
                   {% if svg %}
                   <div class="pollchart pollchart--{{gridsize}}">


### PR DESCRIPTION
DO NOT MERGE.

At moment I am displaying the date of the last ETL (scraper run) rather
than the date of the last poll in the list.

This is far as I can safely get without understanding and refactoring
`drawChart.js` to extract the the date of the most recent poll. I think it's worth doing that because it currently has lot of duplication of data logic going on.
