### PR TITLE
🐛 Removes duplicate 'scripts' stanza in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,10 +76,6 @@
   },
   "main": "setup.js",
   "private": true,
-  "scripts": {
-    "dev": "nodemon setup.js -e js,html,svg",
-    "start": "node setup.js"
-  },
   "engines": {
     "node": "6.x.x"
   }


### PR DESCRIPTION
A duplicate `scripts` section was added to `package.json` during a merge somewhere. This removes it.
