### PR TITLE
🐛 Fixes #180: Please only use ISO-8601 dates with Moment.

### DIFF
--- a/server/pages/page.js
+++ b/server/pages/page.js
@@ -48,7 +48,7 @@ export default class Page {
     this.onwardJourney = onwardJourney();
     this.siteNav = siteNav();
 
-    const electionDay = moment('November 8, 2016');
+    const electionDay = moment('2016-11-08');
     const todayDay = moment();
     this.daysToElection = electionDay.diff(todayDay, 'days');
   }


### PR DESCRIPTION
I don't think this will negatively effect anything, but would appreciate if @joannaskao could confirm it won't impact anything downstream before merging. Thanks!
