### PR TITLE
Add cookie message flag

### DIFF
--- a/config/flags.js
+++ b/config/flags.js
@@ -15,4 +15,5 @@ export default () => ({
   footer: true,
   stateList: true,
   headerMarketingPromo: true,
+  cookieMessage: prod,
 });


### PR DESCRIPTION
This turns on the lovely cookie message for users who should see it.

<img width="1229" alt="us_election_polls_2016" src="https://cloud.githubusercontent.com/assets/684559/19234831/017d1582-8ee6-11e6-9d5a-3081a4b4676f.png">
