### PR TITLE
Dotmap labels: remove white stroke and adjust font smoothing

### DIFF
--- a/views/includes/results-dot-map.svg
+++ b/views/includes/results-dot-map.svg
@@ -12,13 +12,12 @@
 		font-family:'Metric-Regular', 'Metric', sans-serif;
 		font-size:16px;
 		fill:#74736c;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
 	}
 
 	.annotation-backing .map-labels{
-		stroke-linejoin:round;
-		stroke:#FFF;
-		stroke-opacity:0.5;
-		stroke-width:3px;
+		fill: none;
 	}
 
 	.standard-map.annotation-backing .map-labels{


### PR DESCRIPTION
before:
![image](https://cloud.githubusercontent.com/assets/250617/19836711/d79d93d4-9ea0-11e6-8d33-63a42fa7786a.png)

after:
![image](https://cloud.githubusercontent.com/assets/250617/19836710/ccb5338c-9ea0-11e6-90cd-0553223c7409.png)
