### PR TITLE
Always load dotenv

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,7 +1,3 @@
-import dotenv from 'dotenv';
-
-dotenv.load({ silent: true });
-
 export default Object.freeze({
   development: Object.freeze({
     username: process.env.PGUSER,

--- a/setup.js
+++ b/setup.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ silent: true });
+
 process.on('unhandledRejection', error => {
   console.error('unhandledRejection', error.stack);
   process.exit(1);


### PR DESCRIPTION
Currently `.env` is only loaded into `process.env` at some arbitrary point halfway through app startup (whenever the db/config.js file happens to get loaded). This means you can't set `ELECTION_RESULTS=TRUE` in a `.env` file, for example.